### PR TITLE
Documentar rótulos

### DIFF
--- a/pages/contributing/contributing.md
+++ b/pages/contributing/contributing.md
@@ -116,9 +116,10 @@ Exemplo: `feature/1-<feature-name>` (_issue_ #1)
 
 ## Histórico de Versão
 
-| Data       | Versão   | Descrição                                         | Autor(es)       |
-| ---------- | ------   | ------------------------------------------------- | --------------- |
-| 10/11/2022 | 0.1.0    | Criação do documento                              | Paulo Batista   |
-| 15/11/2022 | 0.1.1    | Ajustar documento                                 | Paulo Batista   |
-| 23/11/2022 | 0.2.0    | Nova política de padrão para melhorias            | Lude Ribeiro    |
-| 08/12/2022 | 0.2.1    | Corrigir item de lista formatado como parágrafo   | Davi Antônio    |
+| Data       | Versão   | Descrição                                               | Autor(es)       |
+| ---------- | ------   | ------------------------------------------------------- | --------------- |
+| 10/11/2022 | 0.1.0    | Criação do documento                                    | Paulo Batista   |
+| 15/11/2022 | 0.1.1    | Ajustar documento                                       | Paulo Batista   |
+| 23/11/2022 | 0.2.0    | Nova política de padrão para melhorias                  | Lude Ribeiro    |
+| 08/12/2022 | 0.2.1    | Corrigir item de lista formatado como parágrafo         | Davi Antônio    |
+| 09/12/2022 | 0.2.2    | Explicar rótulos, inclusão de *issues* e escrita de PRs | Davi Antônio    |


### PR DESCRIPTION
Adiciona a documentação sobre as *tags*/rótulos/etiquetas disponíveis nos repositórios e como devem ser usadas para  rotular *issues* que serão cadastrados no repositório Docs.

As instruções para inclusão de *issues* e escrita de solicitações de modificação (*merge/pull requests*) receberam adições para melhorar sua compreensão e facilitar a gerência de modificações do projeto.

Closes: fga-eps-mds/2022-2-CAPJu-Doc#34